### PR TITLE
fix: wrong description for `PSP34Enumerable::token_by_index` selector

### DIFF
--- a/PSPs/psp-34.md
+++ b/PSPs/psp-34.md
@@ -423,7 +423,7 @@ Selector: `0x3bcfb511` - first 4 bytes of `blake2b_256("PSP34Enumerable::owners_
 ```
 
 ##### **token_by_index**(index: u128) -> Option<Id>
-Selector: `0xcd0340d0` - first 4 bytes of `blake2b_256("PSP37Enumerable::owners_token_by_index")`
+Selector: `0xcd0340d0` - first 4 bytes of `blake2b_256("PSP34Enumerable::token_by_index")`
 ```json
 {
   "args": [


### PR DESCRIPTION
Just notice that the description for `token_by_index` function selector is completely wrong. 